### PR TITLE
SEA-326: Removes GHG button from nav menu.

### DIFF
--- a/angular/src/app/layout-components/navigation-bar/navigation-bar.component.html
+++ b/angular/src/app/layout-components/navigation-bar/navigation-bar.component.html
@@ -9,12 +9,6 @@
                 <div class="menu-link-text">Your Plan</div>
                 <div class="more-icon" [inlineSVG]="'controls/expand-arrow.svg'"></div>
             </a>
-            <a class="green-homes-grant-link" *ngIf="!showYourPlan"
-               routerLink="/pages/green-homes-grant/"
-                    (click)="navLinkClicked('Green Homes Grant')">
-                <div class="menu-link-text">Green Homes Grant</div>
-                <div class="more-icon" [inlineSVG]="'controls/expand-arrow.svg'"></div>
-            </a>
         </div>
 
         <a routerLink="/" class="menu-item" (click)="navLinkClicked('Home')">Home

--- a/angular/src/app/layout-components/navigation-bar/navigation-bar.component.scss
+++ b/angular/src/app/layout-components/navigation-bar/navigation-bar.component.scss
@@ -102,17 +102,6 @@
       margin: 2px 0 0 auto;
     }
   }
-
-  .green-homes-grant-link {
-    @extend .highlighted-link;
-
-    background-color: $ghg-banner-green;
-    color: $dark-grey;
-
-    .more-icon {
-      fill: $dark-grey;
-    }
-  }
 }
 
 // Breakpoint specific styling

--- a/angular/src/styles/var/_colors.scss
+++ b/angular/src/styles/var/_colors.scss
@@ -23,6 +23,5 @@ $icon-blue: #01ABCE;
 $light-blue: #BEE8F1;
 $dark-green: #355F43;
 $light-green: #def1c8;
-$ghg-banner-green: #b8ff69;
 
 $cookie-banner: #7d4052;


### PR DESCRIPTION
**Change**
Removes the green homes grant button and related styling from the nav bar.

**Testing** 
I have checked that locally the button is no longer present and the "Your Plan" button is not initially displayed, but is still displayed when you create a plan. Works on desktop and mobile.

**Risks**
Low, small change.

**Docs**
Not required. 