### PR TITLE
SEA-329: Adds section to advertise for user research participants

### DIFF
--- a/angular/src/app/home-page/home-page.component.html
+++ b/angular/src/app/home-page/home-page.component.html
@@ -30,7 +30,7 @@
                 We are looking for people we can talk to, to understand their experience of using the website so that
                 we can improve the future of the Simple Energy Advice service.
             </p>
-            <app-link-button [linkUrl]="'https://forms.office.com/Pages/ResponsePage.aspx?id=BXCsy8EC60O0l-ZJLRst2GVDoJgMSwhFg5ngX7kMGzdUQVcwNlFHVFkwQVc5RUlXWEYzOTlKUVpQQiQlQCN0PWcu'"
+            <app-link-button [linkUrl]="'https://forms.office.com/Pages/ResponsePage.aspx?id=BXCsy8EC60O0l-ZJLRst2HytqWxyMmtPjqqSCBalnExUNEdQOFdNVVJIQjhLNTUwTENPUjk2UjJPVy4u'"
                              [buttonText]="'Get Involved'"
                              [openInNewTab]="true">
             </app-link-button>

--- a/angular/src/app/home-page/home-page.component.html
+++ b/angular/src/app/home-page/home-page.component.html
@@ -22,6 +22,20 @@
             </div>
         </div>
     </div>
+    <div class="research-participant-section page-row">
+        <div class="page-row-content">
+            <h2 class="heading">Help us to improve our service</h2>
+            <p class="summary">Get involved in making Simple Energy Advice better</p>
+            <p>
+                We are looking for people we can talk to, to understand their experience of using the website so that
+                we can improve the future of the Simple Energy Advice service.
+            </p>
+            <app-link-button [linkUrl]="'https://forms.office.com/Pages/ResponsePage.aspx?id=BXCsy8EC60O0l-ZJLRst2GVDoJgMSwhFg5ngX7kMGzdUQVcwNlFHVFkwQVc5RUlXWEYzOTlKUVpQQiQlQCN0PWcu'"
+                             [buttonText]="'Get Involved'"
+                             [openInNewTab]="true">
+            </app-link-button>
+        </div>
+    </div>
     <div class="page-row quick-links">
         <a class="quick-link calculator" (click)="onEnergyCalculatorButtonClick()" tabindex="0">
             <h2 class="heading">Try our energy efficiency calculator</h2>

--- a/angular/src/app/home-page/home-page.component.scss
+++ b/angular/src/app/home-page/home-page.component.scss
@@ -152,6 +152,19 @@ $arrow-height: 48px;
     }
   }
 
+  .research-participant-section {
+    padding: 32px 0;
+    background-color: $lighter-grey;
+    .heading {
+      color: $dark-blue;
+      @include page-subheading-font();
+    }
+    .summary {
+      color: $dark-blue;
+      @include page-summary-font();
+    }
+  }
+
   .quick-links {
     .quick-link {
       position: relative;


### PR DESCRIPTION
**Changes**
Added section to advertise for user research participants. This is pretty much the same code and styling as was used for the GHG section (by pretty much, I mean copied with updated class name). I've checked that this looks fine locally and the link correctly opens the supplied form in a new tab.

**Testing**
As above, this runs locally and I can open the form in a new tab. Check out below screenshot for confirmation that this looks ok on desktop & mobile.

**Risks**
Low, this is a small change to add a new section to the homepage, at worst the form does not work or it looks a bit off.

**Docs**
Not needed.

**Screenshots**
Desktop:
![image](https://user-images.githubusercontent.com/71124134/123771494-fe802c80-d8c2-11eb-801b-9db1baf802cc.png)
Mobile:
![image](https://user-images.githubusercontent.com/71124134/123772244-9b42ca00-d8c3-11eb-8703-bb9c5b3e0571.png)
