### PR TITLE
SEA-258: Update so that show your plan link display is updated when recommendations change, not on route change

### DIFF
--- a/angular/src/app/app.component.spec.ts
+++ b/angular/src/app/app.component.spec.ts
@@ -30,6 +30,7 @@ describe('AppComponent', () => {
 
     const mockWordpressPagesService = {getTopLevelPages: () => Observable.of([])};
     const mockUserStateService = {getSessionReference: () => "reference"};
+    const mockRecommendationsService = {hasRecommendationsInPlan$: Observable.of(true)};
 
     const mockCookieService = {
         check: () => {},
@@ -62,7 +63,7 @@ describe('AppComponent', () => {
                 {provide: SVGCacheService, useValue: {setBaseUrl: () => {}}},
                 {provide: CookieService, useValue: mockCookieService},
                 {provide: UserStateService, useValue: mockUserStateService},
-                {provide: RecommendationsService, useValue: {}},
+                {provide: RecommendationsService, useValue: mockRecommendationsService},
                 {provide: ErrorHandler, useClass: GlobalErrorHandler},
                 {provide: PageTitleService, useValue: pageTitleStub},
             ]

--- a/angular/src/app/energy-efficiency/energy-efficiency-results/energy-efficiency-results.component.ts
+++ b/angular/src/app/energy-efficiency/energy-efficiency-results/energy-efficiency-results.component.ts
@@ -71,7 +71,7 @@ export class EnergyEfficiencyResultsComponent implements OnInit {
             );
 
         this.userStateService.saveState();
-        this.isEditing = this.recommendationsService.getRecommendationsInPlan().length > 0;
+        this.isEditing = this.recommendationsService.hasRecommendationsInPlan;
     }
 
     getUserRecommendations(): EnergyEfficiencyRecommendation[] {

--- a/angular/src/app/layout-components/navigation-bar/navigation-bar.component.spec.ts
+++ b/angular/src/app/layout-components/navigation-bar/navigation-bar.component.spec.ts
@@ -20,6 +20,10 @@ describe('NavigationBarComponent', () => {
         fetchTopLevelPages: () => Observable.of([])
     };
 
+    const mockRecommendationsService = {
+        hasRecommendationsInPlan$: Observable.of(true)
+    };
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [ NavigationBarComponent,
@@ -34,7 +38,7 @@ describe('NavigationBarComponent', () => {
             providers: [
                 {provide: WordpressPagesService, useValue: mockWordpressPagesService},
                 {provide: WordpressSearchService, useValue: {}},
-                {provide: RecommendationsService, useValue: {}},
+                {provide: RecommendationsService, useValue:  mockRecommendationsService},
                 GoogleAnalyticsService,
             ]
         })

--- a/angular/src/app/layout-components/navigation-bar/navigation-bar.component.ts
+++ b/angular/src/app/layout-components/navigation-bar/navigation-bar.component.ts
@@ -1,16 +1,17 @@
-import {Component, EventEmitter, Input, Output, Renderer2, ViewChild} from '@angular/core';
+import {Component, EventEmitter, Input, Output, Renderer2, ViewChild, OnDestroy} from '@angular/core';
 import {NavigationStart, Router, NavigationEnd} from "@angular/router";
 
 import {NavigationSuboption} from "./navigation-suboption";
 import {RecommendationsService} from "../../shared/recommendations-service/recommendations.service";
 import {GoogleAnalyticsService} from "../../shared/analytics/google-analytics.service";
+import { Subscription } from '../../../../node_modules/rxjs';
 
 @Component({
     selector: 'app-navigation-bar',
     templateUrl: './navigation-bar.component.html',
     styleUrls: ['./navigation-bar.component.scss']
 })
-export class NavigationBarComponent {
+export class NavigationBarComponent implements OnDestroy {
     homeSuboptions: NavigationSuboption[] = [
         {
             name: "Heating & Hot Water",
@@ -51,6 +52,8 @@ export class NavigationBarComponent {
     showHomeMenu: boolean = false;
     showRentedMenu: boolean = false;
     showYourPlan: boolean = false;
+    recommendationsInPlanSubscription: Subscription;
+    routerSubscription: Subscription;
 
     @Input() shouldExpandNav: boolean;
     @Output() onHideMobileNav: EventEmitter<null> = new EventEmitter<null>();
@@ -62,28 +65,25 @@ export class NavigationBarComponent {
                 private router: Router,
                 private recommendationsService: RecommendationsService,
                 private googleAnalyticsService: GoogleAnalyticsService) {
-        router.events.subscribe((event) => {
+
+        this.recommendationsInPlanSubscription = this.recommendationsService.hasRecommendationsInPlan$
+            .subscribe((event) => { this.showYourPlan = event; });
+
+        this.routerSubscription = this.router.events.subscribe((event) => {
             if (event instanceof NavigationStart && this.shouldExpandNav) {
                 this.hideMobileNav();
             }
-            // This needs to be regularly checked as it could change quite often.
-            // Performing it on a routing change is a suitable time to do this.
-            this.showYourPlan = this.recommendationsService.getRecommendationsInPlan().length > 0;
-
-            // Existing recommendations are cleared when a questionnaire component is loaded.
-            // This happens after the NavigationEnd event and so we need to set this property as false
-            // explicitly when navigating to a questionnaire page.
-            // TODO SEA-258: Make this less hacky by moving display management of showYourPlan to somewhere more sensible.
-            if (event instanceof NavigationEnd) {
-                if (event.url.includes("questionnaire")) {
-                    this.showYourPlan = false;
-                }
-            }
         });
+
         // This component listens to all click and keyup events, and never de-registers
         // for simplicity as it persists for the life of the SPA
         this.renderer.listen('window', 'keyup', event => this.handleKeyup(event));
         this.renderer.listen('window', 'click', event => this.handleClick(event));
+    }
+
+    ngOnDestroy(): void {
+        this.recommendationsInPlanSubscription.unsubscribe();
+        this.routerSubscription.unsubscribe();
     }
 
     handleKeyup(event): void {

--- a/angular/src/app/shared/recommendations-service/recommendations.service.ts
+++ b/angular/src/app/shared/recommendations-service/recommendations.service.ts
@@ -20,11 +20,15 @@ import {FullMeasuresResponse} from "../energy-calculation-api-service/response/f
 import {EnergyEfficiencyRecommendations} from "./energy-efficiency-recommendations";
 import {SessionService} from "../session-service/session.service";
 import {InstallationCost} from "./installation-cost";
+import { Subject } from '../../../../node_modules/rxjs';
 
 const RECOMMENDATIONS_SESSION_KEY = "recommendations";
 
 @Injectable()
 export class RecommendationsService {
+
+    public hasRecommendationsInPlanSource = new Subject<boolean>();
+    public hasRecommendationsInPlan$ = this.hasRecommendationsInPlanSource.asObservable();
 
     private static TOP_RECOMMENDATIONS: number = 5;
     private static DEFAULT_RECOMMENDATIONS: EnergyEfficiencyRecommendations = new EnergyEfficiencyRecommendations();
@@ -35,7 +39,16 @@ export class RecommendationsService {
     constructor(private sessionResponseData: ResponseData,
                 private measureService: EnergySavingMeasureContentService,
                 private grantsEligibilityService: GrantEligibilityService) {
+        this.initialiseRecommendations();
+    }
+
+    initialiseRecommendations() {
         this.getSessionRecommendations();
+        this.hasRecommendationsInPlanSource.next(this.hasRecommendationsInPlan);
+    }
+
+    get hasRecommendationsInPlan(): boolean {
+        return this.getRecommendationsInPlan().length > 0;
     }
 
     getAllRecommendations(energyCalculation: EnergyCalculationResponse): Observable<EnergyEfficiencyRecommendations> {
@@ -75,11 +88,13 @@ export class RecommendationsService {
 
     updateSessionRecommendations() {
         SessionService.saveToSession(RECOMMENDATIONS_SESSION_KEY, this.recommendations);
+        this.hasRecommendationsInPlanSource.next(this.hasRecommendationsInPlan);
     }
 
     clearRecommendations() {
         this.removeRecommendationsFromSession();
         this.recommendations = new EnergyEfficiencyRecommendations();
+        this.hasRecommendationsInPlanSource.next(this.hasRecommendationsInPlan);
     }
 
     private refreshAllRecommendations(energyCalculation: EnergyCalculationResponse): Observable<EnergyEfficiencyRecommendations> {


### PR DESCRIPTION
**Changes**
Currently the navigation component checks whether there are recommendations in the plan when there is a route change. This is not ideal, we have changed this so that the recommendation service publishes an event when the recommendations change. The nav bar subscribes to this event and updates the display of the "Your plan" as required. This shouldn't really change how the system works, although it does actually fix a bug as it now correctly shows/ hides the button on the edit your plan page when you add and remove things from your plan.

**Testing**
I've checked that the button appears once you have added items to your plan. I have checked that removing them hides the button. When you go back to the questionnaire, the button is hidden. When you refresh the page and have recommendations in the session (with some added to your plan), the button correctly shows.

**Risks**
Some risk, we have changed the way this works, although I have tested as many scenarios as I can think of.

**Docs**
Not required