### PR TITLE
SEA-345: Update card on home energy grant page to display BUS info instead of RHI

### DIFF
--- a/angular/src/app/grants/landing-page/grants-landing-page.component.html
+++ b/angular/src/app/grants/landing-page/grants-landing-page.component.html
@@ -82,15 +82,16 @@
                     </div>
                 </a>
                 <a class="grant-card" (click)="setJourneyTypeToBoiler()"
-                   routerLink="/pages/renewable-heat-incentive">
+                   routerLink="/pages/boiler-upgrade-scheme">
                     <div class="grant-info-column">
                         <div class="grant-info-column icon">
                             <div class="icon-rhi"></div>
                         </div>
-                        <h3 class="grant-heading">Be rewarded for renewable heat</h3>
+                        <h3 class="grant-heading">Switch to low carbon heating</h3>
                         <div class="description-link-container">
                             <div class="grant-description">
-                                If you use renewable energy to heat your home, you can benefit financially from the Renewable Heat Incentive (RHI) scheme.
+                                If you are interested in moving to a greener heating system the boiler upgrade system
+                                (BUS) provides grants to cover your upfront costs.
                             </div>
                             <div class="link-button link-button-arrow">
                                 Find out more


### PR DESCRIPTION
Updates the text and linked page on the grant card on the home energy grant page.

Have confirmed with the client that the logo will not change.